### PR TITLE
Allows users to log in to the api via email instead of username.

### DIFF
--- a/lma/api/serializer_auth_token.py
+++ b/lma/api/serializer_auth_token.py
@@ -1,0 +1,34 @@
+from django.contrib.auth import authenticate
+from django.utils.translation import gettext_lazy as _
+from django.contrib.auth import get_user_model
+from rest_framework import serializers
+
+
+class AuthTokenSerializer(serializers.Serializer):
+    email = serializers.EmailField(label=_('Email'))
+    password = serializers.CharField(
+        label=_("Password"),
+        style={'input_type': 'password'},
+        trim_whitespace=False
+    )
+
+    def validate(self, attrs):
+        email = attrs.get('email')
+        password = attrs.get('password')
+
+        if email and password:
+
+            user = authenticate(request=self.context.get('request'), email=email, password=password)
+
+            # The authenticate call simply returns None for is_active=False
+            # users. (Assuming the default ModelBackend authentication
+            # backend.)
+            if not user:
+                msg = _('Unable to log in with provided credentials.')
+                raise serializers.ValidationError(msg, code='authorization')
+        else:
+            msg = _('Must include "username" and "password".')
+            raise serializers.ValidationError(msg, code='authorization')
+
+        attrs['user'] = user
+        return attrs

--- a/lma/api/view_auth_token.py
+++ b/lma/api/view_auth_token.py
@@ -1,0 +1,19 @@
+from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.authtoken.models import Token
+from rest_framework.response import Response
+from .serializer_auth_token import AuthTokenSerializer
+
+class AuthTokenView(ObtainAuthToken):
+    serializer_class = AuthTokenSerializer
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.serializer_class(data=request.data,
+                                           context={'request': request})
+        serializer.is_valid(raise_exception=True)
+        user = serializer.validated_data['user']
+        token, created = Token.objects.get_or_create(user=user)
+        return Response({
+            'token': token.key,
+            'user_id': user.pk,
+            'email': user.email
+        })

--- a/lma/lma/urls.py
+++ b/lma/lma/urls.py
@@ -15,9 +15,9 @@ Including another URLconf
 """
 from django.urls import include, path
 from rest_framework import routers
-from rest_framework.authtoken import views as token_view
 from api import views
 from django.conf.urls import url
+from api.view_auth_token import AuthTokenView
 
 router = routers.DefaultRouter()
 router.register(r'user', views.UserViewSet, 'user')
@@ -36,7 +36,7 @@ urlpatterns = [
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     # path('api-token-auth/', token_view.obtain_auth_token, name='api-token-auth')
     # url(r'api-token-auth/', views.Authenticate.as_view())
-    url(r'^api-token-auth/', token_view.obtain_auth_token),
+    url(r'^api-token-auth/', AuthTokenView.as_view()),
     path('verify-email/', views.VerifyEmail.as_view(), name='verify-email'),
     # url(r'register/', views.RegisterView.as_view(), name='register'),
 ]


### PR DESCRIPTION
By default, Django Rest Framework will always use "username" to try logging users in. We have to manually override the authentication view used by the framework in order to make it use "email".